### PR TITLE
Update ttreplay.asm

### DIFF
--- a/code/ttreplay.asm
+++ b/code/ttreplay.asm
@@ -329,7 +329,7 @@ NTSC:
 	ld	(hl),a						
  	ld	(equalization_flag),a		
 
-	call	NZ,replay_decodedata_NO	
+;	call	NZ,replay_decodedata_NO	
 	xor	a
 	ld	(equalization_flag),a
 	ret


### PR DESCRIPTION
Line 332 is strange: call NZ,replay_decodedata_NO never jumps as this branch occurs only if we have Z flag set
Or you remove it or you need to replace call nz by call
